### PR TITLE
Fails if tracrpc import not available

### DIFF
--- a/TracUserSelectField/userselectfield.py
+++ b/TracUserSelectField/userselectfield.py
@@ -1,12 +1,9 @@
 # -*- coding: utf8 -*-
 
-from trac import util
 from trac.core import *
 from trac.ticket import TicketSystem, TicketFieldList
 from trac.cache import cached
 from trac.perm import PermissionSystem, PermissionCache
-from tracrpc.ticket import TicketRPC
-from trac.config import ConfigSection, ListOption
 from trac.web import IRequestHandler
 from trac.ticket.default_workflow import ConfigurableTicketWorkflow
 
@@ -125,5 +122,3 @@ class UserSelectFieldPlugin(Component):
             append_owners(users_perms_and_groups)
 
             return sorted(owners)
-
-

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@
 
 
 '''
-Created on 2014-03-12 
+Created on 2014-03-12
 
 @author: cauly
 '''
 from setuptools import find_packages, setup
 
 setup(
-    name='TracUserSelectFieldPlugin', version='1.0',
+    name='TracUserSelectFieldPlugin', version='1.1',
     packages=find_packages(exclude=['*.tests*']),
     license = "BSD 3-Clause",
     author_email='cauliflower.kan@gmail.com',


### PR DESCRIPTION
```
12:42:20 Trac[loader] ERROR: Skipping "tracuserselectfieldplugin = TracUserSelectField": ImportError: No module named tracrpc.ticket
```

There are several unused imports, including `tracrpc`.